### PR TITLE
Use HTTP urls for GCS uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ dist-ssr
 .env
 .next/
 next-env.d.ts
+tsconfig.tsbuildinfo

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -23,6 +23,6 @@ export async function POST(req: NextRequest) {
   await storage.bucket(bucketName).file(filename).save(buffer, {
     contentType: file.type,
   });
-  const url = `gs://${bucketName}/${filename}`;
+  const url = `https://storage.googleapis.com/${bucketName}/${filename}`;
   return NextResponse.json({ url });
 }

--- a/src/components/thread/ContentBlocksPreview.tsx
+++ b/src/components/thread/ContentBlocksPreview.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import type { Base64ContentBlock } from "@langchain/core/messages";
+import type {
+  URLContentBlock,
+  Base64ContentBlock,
+} from "@langchain/core/messages";
 import { MultimodalPreview } from "./MultimodalPreview";
 import { cn } from "@/lib/utils";
 
 interface ContentBlocksPreviewProps {
-  blocks: Base64ContentBlock[];
+  blocks: (URLContentBlock | Base64ContentBlock)[];
   onRemove: (idx: number) => void;
+  progress?: Record<string, number>;
   size?: "sm" | "md" | "lg";
   className?: string;
 }
@@ -17,21 +21,29 @@ interface ContentBlocksPreviewProps {
 export const ContentBlocksPreview: React.FC<ContentBlocksPreviewProps> = ({
   blocks,
   onRemove,
+  progress = {},
   size = "md",
   className,
 }) => {
   if (!blocks.length) return null;
   return (
     <div className={cn("flex flex-wrap gap-2 p-3.5 pb-0", className)}>
-      {blocks.map((block, idx) => (
-        <MultimodalPreview
-          key={idx}
-          block={block}
-          removable
-          onRemove={() => onRemove(idx)}
-          size={size}
-        />
-      ))}
+      {blocks.map((block, idx) => {
+        const name =
+          block.type === "image"
+            ? String(block.metadata?.name)
+            : String(block.metadata?.filename);
+        return (
+          <MultimodalPreview
+            key={idx}
+            block={block}
+            removable
+            onRemove={() => onRemove(idx)}
+            size={size}
+            progress={progress[name]}
+          />
+        );
+      })}
     </div>
   );
 };

--- a/src/components/thread/MultimodalPreview.tsx
+++ b/src/components/thread/MultimodalPreview.tsx
@@ -1,14 +1,18 @@
 import React from "react";
 import { File, Image as ImageIcon, X as XIcon } from "lucide-react";
-import type { Base64ContentBlock } from "@langchain/core/messages";
+import type {
+  URLContentBlock,
+  Base64ContentBlock,
+} from "@langchain/core/messages";
 import { cn } from "@/lib/utils";
 import Image from "next/image";
 export interface MultimodalPreviewProps {
-  block: Base64ContentBlock;
+  block: URLContentBlock | Base64ContentBlock;
   removable?: boolean;
   onRemove?: () => void;
   className?: string;
   size?: "sm" | "md" | "lg";
+  progress?: number;
 }
 
 export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
@@ -17,15 +21,19 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
   onRemove,
   className,
   size = "md",
+  progress,
 }) => {
   // Image block
   if (
     block.type === "image" &&
-    block.source_type === "base64" &&
+    (block.source_type === "base64" || block.source_type === "url") &&
     typeof block.mime_type === "string" &&
     block.mime_type.startsWith("image/")
   ) {
-    const url = `data:${block.mime_type};base64,${block.data}`;
+    const url =
+      block.source_type === "base64"
+        ? `data:${block.mime_type};base64,${(block as Base64ContentBlock).data}`
+        : (block as URLContentBlock).url;
     let imgClass: string = "rounded-md object-cover h-16 w-16 text-lg";
     if (size === "sm") imgClass = "rounded-md object-cover h-10 w-10 text-base";
     if (size === "lg") imgClass = "rounded-md object-cover h-24 w-24 text-xl";
@@ -38,6 +46,16 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
           width={size === "sm" ? 16 : size === "md" ? 32 : 48}
           height={size === "sm" ? 16 : size === "md" ? 32 : 48}
         />
+        {progress !== undefined && progress < 1 && (
+          <div className="absolute inset-0 flex items-end justify-center">
+            <div className="h-2 w-3/4 rounded bg-gray-200">
+              <div
+                className="h-full rounded bg-teal-600"
+                style={{ width: `${Math.floor(progress * 100)}%` }}
+              />
+            </div>
+          </div>
+        )}
         {removable && (
           <button
             type="button"
@@ -55,7 +73,7 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
   // PDF block
   if (
     block.type === "file" &&
-    block.source_type === "base64" &&
+    (block.source_type === "base64" || block.source_type === "url") &&
     block.mime_type === "application/pdf"
   ) {
     const filename =
@@ -81,6 +99,14 @@ export const MultimodalPreview: React.FC<MultimodalPreviewProps> = ({
         >
           {String(filename)}
         </span>
+        {progress !== undefined && progress < 1 && (
+          <div className="absolute right-0 bottom-0 left-0 mx-3 mb-1 h-1 rounded bg-gray-200">
+            <div
+              className="h-full rounded bg-teal-600"
+              style={{ width: `${Math.floor(progress * 100)}%` }}
+            />
+          </div>
+        )}
         {removable && (
           <button
             type="button"

--- a/src/components/thread/index.tsx
+++ b/src/components/thread/index.tsx
@@ -135,6 +135,7 @@ export function Thread() {
     resetBlocks,
     dragOver,
     handlePaste,
+    uploadProgress,
   } = useFileUpload();
   const [firstTokenReceived, setFirstTokenReceived] = useState(false);
   const isLargeScreen = useMediaQuery("(min-width: 1024px)");
@@ -475,6 +476,7 @@ export function Thread() {
                       <ContentBlocksPreview
                         blocks={contentBlocks}
                         onRemove={removeBlock}
+                        progress={uploadProgress}
                       />
                       <textarea
                         value={input}

--- a/src/components/thread/messages/human.tsx
+++ b/src/components/thread/messages/human.tsx
@@ -6,7 +6,10 @@ import { cn } from "@/lib/utils";
 import { Textarea } from "@/components/ui/textarea";
 import { BranchSwitcher, CommandBar } from "./shared";
 import { MultimodalPreview } from "@/components/thread/MultimodalPreview";
-import { isBase64ContentBlock } from "@/lib/multimodal-utils";
+import {
+  isBase64ContentBlock,
+  isURLContentBlock,
+} from "@/lib/multimodal-utils";
 
 function EditableContent({
   value,
@@ -92,11 +95,14 @@ export function HumanMessage({
               <div className="flex flex-wrap items-end justify-end gap-2">
                 {message.content.reduce<React.ReactNode[]>(
                   (acc, block, idx) => {
-                    if (isBase64ContentBlock(block)) {
+                    if (
+                      isBase64ContentBlock(block) ||
+                      isURLContentBlock(block)
+                    ) {
                       acc.push(
                         <MultimodalPreview
                           key={idx}
-                          block={block}
+                          block={block as any}
                           size="md"
                         />,
                       );


### PR DESCRIPTION
## Summary
- return public HTTPS URL from the upload API

## Testing
- `npx prettier -w src/app/api/upload/route.ts`
- `npx tsc -p tsconfig.json`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68613109eb0483249beac2c79d020157